### PR TITLE
feat: react-navigation 5.x can't find variable hydratedState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 node_modules
 .idea/
+.history/

--- a/GIOInjector.js
+++ b/GIOInjector.js
@@ -312,7 +312,7 @@ function onNavigationStateChangeTransformer6(content) {
   if (index == -1) throw "index is -1";
   content =
     content.substring(0, index) +
-    common.anonymousJsFunctionCall(navigationString6("hydratedState")) +
+    common.anonymousJsFunctionCall(navigationString6("getRootState()")) +
     "\n" +
     content.substring(index);
   return content;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-autotrack-growingio",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "GrowingIO autotrack SDK for ReactNative",
   "main": "hook.js",
   "files": [


### PR DESCRIPTION
react-navigation 5.x 不存在hydratedState, 需要主动调用getRootState()