### PR TITLE
fix:p/pg historical legacy issues

### DIFF
--- a/GIOInjector.js
+++ b/GIOInjector.js
@@ -535,13 +535,14 @@ function navigationString3(prevStateVarName, currentStateVarName, actionName) {
 /**
  * 6.x版本该变量名无变化，可以直接使用
  * 采用拼接构造路径，参考checkDuplicateRouteNames
+ * 历史遗留问题 p/pg 路径问题
  */
 function navigationString6(hydratedState) {
   var raw = "${path}/${route.name}";
   var script = `function $$$getActivePageName$$$(state){
 		if(!state)
 			return null;
-		let path = 'Root';
+		let path = '/Root';
 		let route = state.routes[state.index];
 		while(route.state) {
 			path = \`${raw}\`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-autotrack-growingio",
-  "version": "0.0.11-beta.0",
+  "version": "0.0.11",
   "description": "GrowingIO autotrack SDK for ReactNative",
   "main": "hook.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-autotrack-growingio",
-  "version": "0.0.10",
+  "version": "0.0.11-beta.0",
   "description": "GrowingIO autotrack SDK for ReactNative",
   "main": "hook.js",
   "files": [


### PR DESCRIPTION
老saas上，因为p/pg的逻辑存在，所有的路由需要增加前缀/Root来避免被p/pg逻辑影响（实际该逻辑setPageGroup在早期就已经完全废弃）